### PR TITLE
Don't set up queue if write key is not set

### DIFF
--- a/src/SegmentServiceProvider.php
+++ b/src/SegmentServiceProvider.php
@@ -36,9 +36,8 @@ class SegmentServiceProvider extends ServiceProvider
 
         if ($writeKey = $this->app->config->get('segment.write_key')) {
             Segment::init($writeKey, (array) $this->app->config->get('segment.init_options'));
+            $this->setupQueue();
         }
-
-        $this->setupQueue();
     }
 
     /**


### PR DESCRIPTION
Hi,

You've done a nice job cleaning up this fork for PHP 8, but it sounds like Graham isn't too bothered about merging or maintaining it. I've already made this PR against his repo, but I figured it might do better bundled in with your changes, so i thought I'd post it here too.

It simply moves the initial queue setup inside the key check, which means that the queue cleanup functions don't get called on shutdown if you have no key. If you don't do this, and you don't have a key set, it will throw an error at the end of *every* request. If you don't have a key set, it then just fails quietly – which is very useful for dev or staging envs – in my case this issue was causing 32,000 exceptions/day on my staging server before I figured it out!